### PR TITLE
constexpr for compilation problem

### DIFF
--- a/dependencies/aruco_mapping/include/aruco_mapping.h
+++ b/dependencies/aruco_mapping/include/aruco_mapping.h
@@ -157,18 +157,18 @@ private:
    static const int CV_WAIT_KEY = 10;
    static const int CV_WINDOW_MARKER_LINE_WIDTH = 2;
 
-   static const double WAIT_FOR_TRANSFORM_INTERVAL = 2.0;
-   static const double BROADCAST_WAIT_INTERVAL = 0.0001;
-   static const double INIT_MIN_SIZE_VALUE = 1000000;
+   static constexpr double WAIT_FOR_TRANSFORM_INTERVAL = 2.0;
+   static constexpr double BROADCAST_WAIT_INTERVAL = 0.0001;
+   static constexpr double INIT_MIN_SIZE_VALUE = 1000000;
 
-   static const double RVIZ_MARKER_HEIGHT = 0.01;
-   static const double RVIZ_MARKER_LIFETIME = 0.2;
-   static const double RVIZ_MARKER_COLOR_R = 1.0;
-   static const double RVIZ_MARKER_COLOR_G = 1.0;
-   static const double RVIZ_MARKER_COLOR_B = 1.0;
-   static const double RVIZ_MARKER_COLOR_A = 1.0;
+   static constexpr double RVIZ_MARKER_HEIGHT = 0.01;
+   static constexpr double RVIZ_MARKER_LIFETIME = 0.2;
+   static constexpr double RVIZ_MARKER_COLOR_R = 1.0;
+   static constexpr double RVIZ_MARKER_COLOR_G = 1.0;
+   static constexpr double RVIZ_MARKER_COLOR_B = 1.0;
+   static constexpr double RVIZ_MARKER_COLOR_A = 1.0;
 
-   static const double THIS_IS_FIRST_MARKER = -2;
+   static constexpr double THIS_IS_FIRST_MARKER = -2;
 
 }; //ArucoMapping class
 }  //aruco_mapping namespace


### PR DESCRIPTION
fixed error: ‘constexpr’ needed for in-class initialization of static data member ‘const ... on gcc version 7.4.0